### PR TITLE
Support python3.5/debian stretch

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,6 @@ jobs:
     - name: Run lint
       run: make lint
     - name: Prepare test image
-      run: make test-image
+      run: make kissh-test-image-ubuntu kissh-test-image-debian
     - name: Run tests
       run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,8 @@
 #   --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
 #   -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 #
-# We also pre-install our packages, so that tests run faster.
-FROM ubuntu:20.04
+ARG BASE=jrei/systemd-ubuntu:20.04
+FROM $BASE
 
-ENV container=docker
-ENV LC_ALL=C
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y ubuntu-server sudo ssh openssh-server
-
-VOLUME [ "/sys/fs/cgroup" ]
-
-CMD ["/lib/systemd/systemd"]
+# we need sudo and ssh installed
+RUN apt-get update && apt-get install -y sudo ssh openssh-server python3 python3-requests

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #   --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
 #   -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 #
-ARG BASE=jrei/systemd-ubuntu:20.04
+ARG BASE=you-must-set-base-image-explictly
 FROM $BASE
 
 # we need sudo and ssh installed

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ kissh-test-image-debian:
 .PHONY: test
 test: kissh-test-image-ubuntu kissh-test-image-debian
 	$(MAKE) $(TESTS) DISTRO=ubuntu
-	$(MAKE) $(TESTS) DISTO=debian
+	$(MAKE) $(TESTS) DISTRO=debian
 
 
 .PHONY: $(TESTS)

--- a/kissh
+++ b/kissh
@@ -236,7 +236,7 @@ def update_user(userfile, user, public_key):
     # validate the key is set properly on Github
     if get_github_key(user, fingerprint) is None:
         print(
-            "{public_key} is not registerd for Github user {user}".format(
+            "{public_key} is not registered for Github user {user}".format(
                 public_key=public_key,
                 user=user,
             )

--- a/kissh
+++ b/kissh
@@ -24,7 +24,12 @@ HISTORY = Path("/root/.kissh-history")
 def write_history(username):
     """Record username and creation timestamp."""
     with HISTORY.open("a") as history:
-        history.write(f"{username}:{datetime.utcnow().isoformat()}\n")
+        history.write(
+            "{username}:{isodate}\n".format(
+                username=username,
+                isodate=datetime.utcnow().isoformat(),
+            )
+        )
 
 
 def load_history():
@@ -81,8 +86,9 @@ def get_fingerprint(key):
         ["ssh-keygen", "-l", "-f-"],
         input=key,
         check=True,
-        capture_output=True,
-        text=True,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
     )
     # ssh-keygen output format is: "SIZE HASH:VALUE no comment (TYPE)".
     # eg: "256 SHA256:AsFa6mIf22oiMZSW7yNn3Fip2Ri6DAzjrh+KiZ+axWg no comment (ED25519)"
@@ -122,9 +128,9 @@ def manage_user(username, fingerprint):
         if user:
             # remove all keys from users authorized_keys
             user.write_keys("")
-            print(f"Removed SSH keys for user {user}")
+            print("Removed SSH keys for user {user}".format(user=user))
         else:
-            print(f"User {user} does not exist and no valid key found")
+            print("User {user} does not exist and no valid key found".format(user=user))
 
 
 def validate_user(username, fingerprint, historic_user):
@@ -134,21 +140,31 @@ def validate_user(username, fingerprint, historic_user):
     if user:
         if key:
             if get_fingerprint(user.authorized_keys.read_text()) == fingerprint:
-                print(f"User {user} exists has valid authorized_keys")
+                print("User {user} exists has valid authorized_keys".format(user=user))
                 return True
             else:
-                print(f"User {user} exists but has invalid authorized_keys")
+                print(
+                    "User {user} exists but has invalid authorized_keys".format(
+                        user=user
+                    )
+                )
                 return False
         else:
             if historic_user:
-                print(f"Historic user {user} exists but does not have valid key")
+                print(
+                    "Historic user {user} exists but does not have valid key".format(
+                        user=user
+                    )
+                )
                 return True
 
             print(
-                f"User {user} exists but does not have valid key and was not created by kissh"
+                "User {user} exists but does not have valid key and was not created by kissh".format(
+                    user=user
+                )
             )
     else:
-        print(f"User {user} is expected but does not exist on system")
+        print("User {user} is expected but does not exist on system".format(user=user))
 
     return False
 
@@ -164,7 +180,7 @@ def get_users(path):
         user, _, fingerprint = line.partition(":")
 
         if not fingerprint:
-            print(f"Invalid line '{line}' in users file")
+            print("Invalid line '{line}' in users file".format(line=line))
         else:
             yield user, fingerprint
 
@@ -219,13 +235,18 @@ def update_user(userfile, user, public_key):
 
     # validate the key is set properly on Github
     if get_github_key(user, fingerprint) is None:
-        print(f"{keyfile} is not registerd for Github user {user}")
+        print(
+            "{public_key} is not registerd for Github user {user}".format(
+                public_key=public_key,
+                user=user,
+            )
+        )
         return 1
 
     users = dict(get_users(userfile))
     # update user's fingerprint
     users[user] = fingerprint
-    content = "\n".join(f"{u}:{f}" for u, f in users.items())
+    content = "\n".join("{u}:{f}".format(u=u, f=f) for u, f in users.items())
     userfile.write_text(content)
 
 
@@ -240,7 +261,6 @@ def get_parser():
 
     subparsers = parser.add_subparsers(
         title="available commands",
-        required=True,
         description="",
         metavar="COMMAND",
     )

--- a/run-test.sh
+++ b/run-test.sh
@@ -5,14 +5,9 @@
 # Run with DEBUG=1 to run a shell inside the container after running your
 # script
 # 
-# Note: you may need to first build the test image before you can manually run
-# this script:
-#     
-#     make test-image
-#
 set -euo pipefail
 SCRIPT=$1
-TEST_IMAGE=kissh-test
+TEST_IMAGE=$2
 DEBUG=${DEBUG:-}
 
 if test -n "$DEBUG"; then

--- a/tests/change-key-removes-user.sh
+++ b/tests/change-key-removes-user.sh
@@ -55,4 +55,3 @@ echo "$username:SHA256:badfingerprint" > "$userfile"
 
 # check the authorized_keys is empty
 test "$(cat "$authorized_keys")" = ""
-echo "test: $?"

--- a/tests/remove-user.sh
+++ b/tests/remove-user.sh
@@ -3,7 +3,11 @@ set -euo pipefail
 
 tmp=/root/tmp
 mkdir -p $tmp
-trap 'rm -rf $tmp; kill -- -$$' EXIT
+cleanup() {
+    kill -9 $server_pid || true
+    rm -rf $tmp
+}
+trap cleanup EXIT
 
 # create an empty userfile
 userfile=$tmp/passwd
@@ -18,7 +22,8 @@ ssh-keygen -t ed25519 -C "test" -N "" -f "$key"
 test -f "$public"
 
 # serve the file up over http
-python3 -m http.server 8080 --directory "$tmp" &
+(cd "$tmp" && python3 -m http.server 8080)&
+server_pid=$!
 
 # set kissh to user our test data
 export KISSH_USERFILE=$userfile


### PR DESCRIPTION
Trying to deploy this I realised our current infra is on old debian, not
ubuntu.

So rework the python to work with python3.5, i.e. no f-strings, no
capture_output in subprocess.run, and no required argument in argparse

Added parallel tests for ubuntu:20.04 and debian:stretch to makes sure
we don't accidentally break compatibility going forward.