### PR TITLE
Add requests dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ added:
 
     git clone git@github.com:ebmdatalab/kissh.git
     cd kissh
+    
+    pip install requests
 
     ./kissh update YOUR_GITHUB_USERNAME ~/.ssh/datalab_ed25519.pub
 


### PR DESCRIPTION
./kissh requires requests - I just happened to have opened a new shell without a virtualenv when I tried to run it.  A whole requirements.txt seems like overkill so I've just updated the README, but can add that if preferred