### PR TITLE
Add IdentitiesOnly to sample SSH config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ accessing Datalab systems with the following snippet in `~/.ssh/config`
 Host *.ebmdatalab.net *.opensafely.org
     User YOUR_GITHUB_USERNAME
     IdentityFile ~/.ssh/datalab_ed25519
+    IdentitiesOnly yes
 ```
 
 This should allow you to just do `ssh somehost.ebmdatalab.net` and it Just Works.


### PR DESCRIPTION
* required by some devs who have a lot of keys
* also probably good to tighten things up