### PR TITLE
chore: upgrade ubuntu & debian versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ lint:
 
 .PHONY: ubuntu-kissh-test-image debian-kissh-test-image
 kissh-test-image-ubuntu:
-	podman build . -t $@ --build-arg BASE=jrei/systemd-ubuntu:20.04
+	podman build . -t $@ --build-arg BASE=jrei/systemd-ubuntu:22.04
 kissh-test-image-debian:
-	podman build . -t $@ --build-arg BASE=jrei/systemd-debian:9
+	podman build . -t $@ --build-arg BASE=jrei/systemd-debian:10
 
 
 # run all tests


### PR DESCRIPTION
* dokku3/4 are using ubuntu 22.04
* debian stretch (9) tests had broken, upgrade to debian buster (10)